### PR TITLE
【追加】PlayerControllerとCameraControllerの編集

### DIFF
--- a/Shooting/Assets/Scripts/CameraController.cs
+++ b/Shooting/Assets/Scripts/CameraController.cs
@@ -10,13 +10,11 @@ public class CameraController : MonoBehaviour
 	private Vector2 rotationSpeed = new Vector2(0.1f,0.2f);
 	private Vector2 lastMousePosition;
 	private Vector2 currentAngle = new Vector2(0, 0);
-	private Vector3 targetPos;
 	private Vector3 offset;
 
 	void Start()
     {
         offset = transform.position - player.transform.position;
-		targetPos = player.transform.position;
     }
 
     void LateUpdate()
@@ -32,26 +30,19 @@ public class CameraController : MonoBehaviour
 			//カメラの角度を変数に格納
 			currentAngle = mainCamera.transform.localEulerAngles;
 			lastMousePosition = Input.mousePosition;
-			Debug.Log("a");
 		}
 		// 左ドラッグしている間
 		else if(Input.GetMouseButton(0)){ 
 			// Y軸の回転：マウスドラッグ方向に視点回転
-			// マウスの水平移動地に変換
-			// （クリック時の座標とマウス座標の現在地の差分）
 			currentAngle.y -= (Input.mousePosition.x - lastMousePosition.x) * rotationSpeed.y;
 
 			// x軸の回転：マウスドラッグ方向に視点回転
-			// マウスの垂直移動地に変数ろたちおｎSpeedを掛ける
-			// （クリック時の座標とマウス座標の現在地の差分値）
 			currentAngle.x -= (lastMousePosition.y - Input.mousePosition.y) * rotationSpeed.x;
 
-			// angleの角度をカメラ角度に格納
+			// currentAngleの角度をカメラ角度に格納
 			mainCamera.transform.localEulerAngles = currentAngle;
 			// マウス座標を変数lastMousePositionに格納
 			lastMousePosition = Input.mousePosition;
-
-			Debug.Log("b");
 		}
 	}
 }

--- a/Shooting/Assets/Scripts/CameraController.cs
+++ b/Shooting/Assets/Scripts/CameraController.cs
@@ -6,15 +6,52 @@ public class CameraController : MonoBehaviour
 {
 
     public GameObject player;
-    private Vector3 offset;
+	public Camera mainCamera;
+	private Vector2 rotationSpeed = new Vector2(0.1f,0.2f);
+	private Vector2 lastMousePosition;
+	private Vector2 currentAngle = new Vector2(0, 0);
+	private Vector3 targetPos;
+	private Vector3 offset;
 
-    void Start()
+	void Start()
     {
-        offset = transform.position - player.transform.position;   
+        offset = transform.position - player.transform.position;
+		targetPos = player.transform.position;
     }
 
     void LateUpdate()
     {
-        transform.position = player.transform.position + offset;
-    }
+		// カメラの視点移動：LeftShift
+		transform.position = player.transform.position + offset;
+		if (Input.GetKey(KeyCode.LeftShift)) {
+			transform.position = player.transform.position;
+		}
+
+		// ドラッグによる画面移動
+		if (Input.GetMouseButtonDown(0)) {
+			//カメラの角度を変数に格納
+			currentAngle = mainCamera.transform.localEulerAngles;
+			lastMousePosition = Input.mousePosition;
+			Debug.Log("a");
+		}
+		// 左ドラッグしている間
+		else if(Input.GetMouseButton(0)){ 
+			// Y軸の回転：マウスドラッグ方向に視点回転
+			// マウスの水平移動地に変換
+			// （クリック時の座標とマウス座標の現在地の差分）
+			currentAngle.y -= (Input.mousePosition.x - lastMousePosition.x) * rotationSpeed.y;
+
+			// x軸の回転：マウスドラッグ方向に視点回転
+			// マウスの垂直移動地に変数ろたちおｎSpeedを掛ける
+			// （クリック時の座標とマウス座標の現在地の差分値）
+			currentAngle.x -= (lastMousePosition.y - Input.mousePosition.y) * rotationSpeed.x;
+
+			// angleの角度をカメラ角度に格納
+			mainCamera.transform.localEulerAngles = currentAngle;
+			// マウス座標を変数lastMousePositionに格納
+			lastMousePosition = Input.mousePosition;
+
+			Debug.Log("b");
+		}
+	}
 }

--- a/Shooting/Assets/Scripts/PlayerController.cs
+++ b/Shooting/Assets/Scripts/PlayerController.cs
@@ -42,9 +42,6 @@ public class PlayerController : CharaController
 		Vector3 dirHorizontal = new Vector3(Mathf.Cos(angleDir), 0, -Mathf.Sin(angleDir));  // カメラ右正面方向をベクトルで取得
 
 		// Playerの回転制御
-		if (false) {
-
-		}
 
 		
 		// 走る：デフォルト

--- a/Shooting/Assets/Scripts/PlayerController.cs
+++ b/Shooting/Assets/Scripts/PlayerController.cs
@@ -5,21 +5,44 @@ using UnityEngine;
 public class PlayerController : CharaController
 {
 
-    public float speed = 10.0f;
+    public float walkSpeed;
+	public float runSpeed;
     public Rigidbody rb;
-    PlayerController()
-    {
+
+    PlayerController(){
+		HP = 10;
+		Attack = 1;
+		walkSpeed = 0.01f;
+		runSpeed = 0.03f;
     }
-    void Start()
-    {
+
+    void Start(){
         rb = GetComponent<Rigidbody>();     
     }
 
-    void Update()
-    {
-        float x = Input.GetAxis("Horizontal") * speed;
-        float z = Input.GetAxis("Vertical") * speed;
-        rb.AddForce(x, 0, z);
-    }
-    
+	void Update() {
+
+		float horizontal = Input.GetAxis("Horizontal");
+		float vertical = Input.GetAxis("Vertical");
+		bool hold = Input.GetKey(KeyCode.LeftShift);
+
+		// 歩く。構え時には動かない(処理も回さない)。
+		// TODO: AddForceはTranslateに切り替え
+		if (!(horizontal == 0 && vertical == 0) && !hold) {
+			float x = horizontal * walkSpeed;
+			float z = vertical * walkSpeed;
+			rb.AddForce(x, 0, z);
+		}
+		// 構える。"J"で射撃（未実装）。
+		// カメラの視点を変化させる（MainCameraに実装？）。
+		else if (hold) {
+
+			if (Input.GetKey(KeyCode.J)) {
+				Debug.Log("射撃");
+			}
+		} else {
+
+		}
+
+	}
 }

--- a/Shooting/Assets/Scripts/PlayerController.cs
+++ b/Shooting/Assets/Scripts/PlayerController.cs
@@ -5,44 +5,62 @@ using UnityEngine;
 public class PlayerController : CharaController
 {
 
-    public float walkSpeed;
-	public float runSpeed;
-    public Rigidbody rb;
+	/// <summary>
+	/// 利用する際は、
+	/// 1.CameraTransformにPlayerとMainCameraをアタッチしてください。
+	/// 2.適度にパラメータを調整してください。
+	/// </summary>
+
+    public float runSpeed;				// 移動速度
+	public float walkSpeed;				// 歩・走の速度比の調整
+	public float jumpPower;				// ジャンプ力ぅ…ですかね…
+	public Transform CameraTransform;	// 横の視点移動（MainCameraをアタッチ）
+	public float rotateRate;
 
     PlayerController(){
 		HP = 10;
 		Attack = 1;
-		walkSpeed = 0.01f;
-		runSpeed = 0.03f;
+		runSpeed = 4.0f;
+		walkSpeed = 1.0f;
     }
 
-    void Start(){
-        rb = GetComponent<Rigidbody>();     
+    void Start(){     
     }
 
 	void Update() {
 
-		float horizontal = Input.GetAxis("Horizontal");
+		// キー入力用変数
 		float vertical = Input.GetAxis("Vertical");
+		float horizontal = Input.GetAxis("Horizontal");
 		bool hold = Input.GetKey(KeyCode.LeftShift);
+		bool shot = Input.GetKey(KeyCode.J);
+		bool jump = Input.GetKey(KeyCode.Space);
+		
+		// 進行方向制御用変数
+		float angleDir = CameraTransform.transform.eulerAngles.y * (Mathf.PI / 180.0f);		// ワールド座標に対するオイラー角
+		Vector3 dirVertical = new Vector3(Mathf.Sin(angleDir), 0, Mathf.Cos(angleDir));		// カメラ正面方向をベクトルで取得
+		Vector3 dirHorizontal = new Vector3(Mathf.Cos(angleDir), 0, -Mathf.Sin(angleDir));  // カメラ右正面方向をベクトルで取得
 
-		// 歩く。構え時には動かない(処理も回さない)。
-		// TODO: AddForceはTranslateに切り替え
-		if (!(horizontal == 0 && vertical == 0) && !hold) {
-			float x = horizontal * walkSpeed;
-			float z = vertical * walkSpeed;
-			rb.AddForce(x, 0, z);
+		// Playerの回転制御
+		if (false) {
+
 		}
-		// 構える。"J"で射撃（未実装）。
-		// カメラの視点を変化させる（MainCameraに実装？）。
-		else if (hold) {
+
+		
+		// 走る：デフォルト
+		if (!hold) {
+			this.transform.position += dirVertical * vertical * runSpeed * Time.deltaTime;
+			this.transform.position += dirHorizontal * horizontal * runSpeed * Time.deltaTime;
+		}
+
+		// 構える・歩く。"J"で射撃（未実装）。
+		if (hold) {
+			this.transform.position += dirVertical * vertical * walkSpeed * Time.deltaTime;
+			this.transform.position += dirHorizontal * horizontal * walkSpeed * Time.deltaTime;
 
 			if (Input.GetKey(KeyCode.J)) {
 				Debug.Log("射撃");
 			}
-		} else {
-
 		}
-
 	}
 }


### PR DESCRIPTION
## PlayerControllerとCameraControllerの編集
以下の内容を実装しました。（途中の部分もあり）
### PlayerController
  - 走る、構え（歩く）を記述をRigidbodyからtransfrom.positionに書き換え
  - Playerのキー入力による進行方向をカメラ正面基準に変更。
### CameraController
  - Shift入力で視点の切り替え（要調整）
  - 画面ドラッグによる視点の移動（ToDo：キャラへの回り込み）